### PR TITLE
suprime_offset computation

### DIFF
--- a/bin/desi_suprime_photoff
+++ b/bin/desi_suprime_photoff
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+
+
+import os
+import numpy as np
+from desiutil.log import get_logger
+from desiutil.redirect import stdouterr_redirected
+from desihizmerge.suprime_photoff_io import (
+    read_photspecfn,
+    get_offsets,
+    get_ccdnames,
+    get_d_for_plot_offsets,
+    plot_offsets,
+    apply_offsets,
+    get_match_cosmos2020,
+)
+import multiprocessing
+from argparse import ArgumentParser
+
+log = get_logger()
+
+default_outdir = os.path.join(
+    os.getenv("DESI_ROOT"),
+    "users",
+    "raichoor",
+    "laelbg",
+    "suprime",
+    "offsets",
+    "phot-redux-20230307",
+)
+default_photspecfn = os.path.join(
+    default_outdir,
+    "spec",
+    "cosmos-desi-thru20230416-cumulhpx-spectra-unq.fits",
+)
+default_tractorfn = os.path.join(
+    os.getenv("DESI_ROOT"),
+    "users",
+    "raichoor",
+    "laelbg",
+    "suprime",
+    "phot",
+    "Subaru_tractor_forced_all.fits.gz",
+)
+
+
+def parse():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--outdir",
+        help="output folder (default={})".format(default_outdir),
+        type=str,
+        default=default_outdir,
+    )
+    parser.add_argument(
+        "--step",
+        choices=["compute", "plot_star", "plot_laelbg", "plot_cosmos2020"],
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--photspecfn",
+        help="file with all unique objects observed in cosmos, match to Tractor suprime photometry (default={})".format(
+            default_photspecfn,
+        ),
+        type=str,
+        default=default_photspecfn,
+    )
+    parser.add_argument(
+        "--fkey",
+        help="Tractor column to use (default=FIBERTOTFLUX)",
+        choices=["FIBERTOTFLUX", "FIBERFLUX"],
+        type=str,
+        default="FIBERTOTFLUX",
+    )
+    parser.add_argument(
+        "--tractorfn",
+        help="Tractor file where we want to correct the offsets (default={})".format(
+            default_tractorfn
+        ),
+        type=str,
+        default=default_tractorfn,
+    )
+    parser.add_argument(
+        "--log-stdout",
+        "--log_stdout",
+        action="store_true",
+        help="log to stdout instead of redirecting to a file",
+    )
+    parser.add_argument(
+        "--overwrite",
+        help="overwrite files",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    for kwargs in args._get_kwargs():
+        log.info("{}\t{}".format(kwargs[0], kwargs[1]))
+
+    return args
+
+
+def main():
+
+    for kwargs in args._get_kwargs():
+        log.info("{}\t{}".format(kwargs[0], kwargs[1]))
+
+    # output files
+    outphotspecfn = args.photspecfn.replace(".fits", "-with-offsets.fits")
+    outoffsetsfn = os.path.join(args.outdir, "suprime-offsets.ecsv")
+
+    if args.step == "compute":
+
+        for fn in [outphotspecfn, outoffsetsfn]:
+            if (os.path.isfile(fn)) & (~args.overwrite):
+                msg = "{} exists and args.overwrite=False; exiting".format(fn)
+                log.error(msg)
+                raise ValueError(msg)
+
+        # read spec + tractor info; and merge
+        d = read_photspecfn(args.photspecfn)
+
+        # compute offsets + return enhanced catalog
+        d, d_offsets = get_offsets(d, args.fkey)
+
+        # write
+        log.info("write {}".format(outphotspecfn))
+        d.write(outphotspecfn, overwrite=args.overwrite)
+        log.info("write {}".format(outoffsetsfn))
+        d_offsets.write(outoffsetsfn, overwrite=args.overwrite)
+
+    if args.step == "plot_star":
+
+        outpngroot = os.path.join(
+            args.outdir,
+            "plots",
+            "suprime-offsets-star",
+        )
+
+        ccdnames = [None] + get_ccdnames().tolist() + ["all"]
+        d = get_d_for_plot_offsets(outphotspecfn, args.fkey, "star")
+        plot_offsets(d, outpngroot, ccdnames=ccdnames, sample_label="DESI stars")
+
+    if args.step == "plot_laelbg":
+
+        outpngroot = os.path.join(
+            args.outdir,
+            "plots",
+            "suprime-offsets-laelbg",
+        )
+
+        ccdnames = [None]
+        d = get_d_for_plot_offsets(outphotspecfn, args.fkey, "laelbg")
+        plot_offsets(d, outpngroot, ccdnames=ccdnames, sample_label="DESI LAE/LBG")
+
+    if args.step == "plot_cosmos2020":
+
+        outpngroot = os.path.join(
+            args.outdir,
+            "plots",
+            "suprime-offsets-cosmos2020",
+        )
+
+        ccdnames = [None]
+        for fmin, fmin_root in zip(
+            [1, 0.1],
+            ["", "-faint"],
+        ):
+            fmin_outpngroot = "{}{}".format(outpngroot, fmin_root)
+            d = get_match_cosmos2020(args.tractorfn, outoffsetsfn, fmin=fmin)
+            plot_offsets(
+                d, fmin_outpngroot, ccdnames=ccdnames, sample_label="COSMOS2020 stars"
+            )
+
+
+if __name__ == "__main__":
+
+    args = parse()
+
+    if args.step == "compute":
+
+        outfn = args.photspecfn.replace(".fits", "-with-offsets.fits")
+
+    if args.step not in ["compute"]:
+
+        main()
+
+    else:
+
+        outlog = outfn.replace(".fits", ".log")
+
+        if (os.path.isfile(outfn)) & (~args.overwrite):
+
+            msg = "{} exists and args.overwrite=False".format(outfn)
+            log.error(msg)
+            raise ValueError(msg)
+
+        if args.log_stdout:
+
+            main()
+
+        else:
+
+            with stdouterr_redirected(to=outlog):
+
+                main()

--- a/bin/desi_suprime_photspec
+++ b/bin/desi_suprime_photspec
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+
+import os
+import multiprocessing
+import numpy as np
+from astropy.table import Table, vstack
+from astropy.io import fits
+from desihizmerge.hizmerge_io import get_img_bands
+from desihizmerge.suprime_photspec_io import (
+    get_tractor_match,
+    process_fn,
+    build_hs,
+    get_unq_spectra,
+    build_unq_hs,
+)
+from desispec.spectra import stack as spectra_stack
+from desiutil.redirect import stdouterr_redirected
+from desiutil.log import get_logger
+from argparse import ArgumentParser
+
+
+log = get_logger()
+
+default_outdir = os.path.join(
+    os.getenv("DESI_ROOT"),
+    "users",
+    "raichoor",
+    "laelbg",
+    "suprime",
+    "offsets",
+    "phot-redux-20230307",
+)
+default_desicosmosfn = os.path.join(
+    os.getenv("DESI_ROOT"),
+    "users",
+    "raichoor",
+    "cosmos",
+    "cosmos-desi-thru20230416-cumulhpx.fits",
+)
+default_tractorfn = os.path.join(
+    os.getenv("DESI_ROOT"),
+    "users",
+    "raichoor",
+    "laelbg",
+    "suprime",
+    "phot",
+    "Subaru_tractor_forced_all.fits.gz",
+)
+
+
+def parse():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--outdir",
+        help="output folder (default={})".format(default_outdir),
+        type=str,
+        default=default_outdir,
+    )
+    parser.add_argument(
+        "--step",
+        choices=["all", "unq"],
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--desicosmosfn",
+        help="file listing all desi observations in cosmos (default={})".format(
+            default_desicosmosfn
+        ),
+        type=str,
+        default=default_desicosmosfn,
+    )
+    parser.add_argument(
+        "--tractorfn",
+        help="tractor file name (default={})".format(default_tractorfn),
+        type=str,
+        default=default_tractorfn,
+    )
+    parser.add_argument(
+        "--numproc", help="number of parallel process (default=1)", type=int, default=1
+    )
+    parser.add_argument(
+        "--log-stdout",
+        "--log_stdout",
+        action="store_true",
+        help="log to stdout instead of redirecting to a file",
+    )
+    parser.add_argument(
+        "--overwrite",
+        help="overwrite files",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    for kwargs in args._get_kwargs():
+
+        log.info("{}\t{}".format(kwargs[0], kwargs[1]))
+
+    return args
+
+
+def main():
+
+    for kwargs in args._get_kwargs():
+        log.info("{}\t{}".format(kwargs[0], kwargs[1]))
+
+    bands = get_img_bands("suprime")
+
+    if args.step == "all":
+
+        d = Table.read(args.desicosmosfn)
+
+        # match to tractor
+        match_d, match_t = get_tractor_match(d, args.tractorfn)
+
+        rrfns = np.unique(match_d["FN"])
+        # loop on redrock files
+        myargs = [(match_d, match_t, rrfn, bands) for rrfn in rrfns]
+        pool = multiprocessing.Pool(processes=args.numproc)
+
+        with pool:
+
+            outputs = pool.starmap(process_fn, myargs)
+
+        ss = [output[0] for output in outputs]
+        ds = [output[1] for output in outputs]
+        ts = [output[2] for output in outputs]
+
+        s = spectra_stack(ss)
+        d = vstack(ds)
+        t = vstack(ts)
+        assert np.all(s.fibermap["TARGETID"] == d["TARGETID"])
+
+        hs = build_hs(s, d, t)
+
+        log.info("write {}".format(outfn))
+        hs.writeto(outfn, overwrite=args.overwrite)
+
+    if args.step == "unq":
+
+        h = fits.open(outfn.replace("-unq", "-all"))
+        d = Table(h["CUSTOM"].data)
+        t = Table(h["PHOTINFO"].data)
+        waves = h["BRZ_WAVE"].data
+        fluxs = h["BRZ_FLUX"].data
+        ivars = h["BRZ_IVAR"].data
+
+        unq_fluxs, unq_ivars, unq_d, unq_t = get_unq_spectra(
+            d, t, waves, fluxs, ivars, bands
+        )
+
+        hs = build_unq_hs(waves, unq_fluxs, unq_ivars, unq_d, unq_t)
+
+        log.info("write {}".format(outfn))
+        hs.writeto(outfn, overwrite=args.overwrite)
+
+
+if __name__ == "__main__":
+
+    args = parse()
+
+    outfn = os.path.join(
+        args.outdir,
+        os.path.basename(args.desicosmosfn).replace(
+            ".fits", "-spectra-{}.fits".format(args.step)
+        ),
+    )
+    log.info("outfn\t{}".format(outfn))
+
+    outlog = outfn.replace(".fits", ".log")
+
+    if (os.path.isfile(outfn)) & (~args.overwrite):
+
+        msg = "{} exists and args.overwrite=False".format(outfn)
+        log.error(msg)
+        raise ValueError(msg)
+
+    if args.log_stdout:
+
+        main()
+
+    else:
+
+        with stdouterr_redirected(to=outlog):
+
+            main()

--- a/py/desihizmerge/suprime_photoff_io.py
+++ b/py/desihizmerge/suprime_photoff_io.py
@@ -1,0 +1,792 @@
+#!/usr/bin/env python
+
+
+import os
+from glob import glob
+import fitsio
+import numpy as np
+
+from astropy.io import fits
+from astropy.table import Table, vstack
+
+from matplotlib.path import Path
+import matplotlib.pyplot as plt
+from matplotlib import gridspec
+import matplotlib
+
+from desihizmerge.hizmerge_io import get_img_bands, get_cosmos2020_fn, match_coord
+
+from desiutil.log import get_logger
+
+log = get_logger()
+
+
+def get_suprime_dir():
+
+    return os.path.join(os.getenv("DESI_ROOT"), "users", "dstn", "suprime")
+
+
+def get_get_suprime_annotated_ccdfn():
+
+    suprime_dir = get_suprime_dir()
+    return os.path.join(suprime_dir, "ccds-annotated-suprime-IA.fits")
+
+
+def get_suprime_brn_ccdfn(brn):
+
+    suprime_dir = get_suprime_dir()
+    return os.path.join(
+        suprime_dir,
+        "catalogs",
+        "coadd",
+        brn[:3],
+        brn,
+        "legacysurvey-{}-ccds.fits".format(brn),
+    )
+
+
+def get_ccdnames():
+
+    return np.array(["det{}".format(_) for _ in range(10)])
+
+
+def get_tractor_band(band, uppercase=True):
+    if uppercase:
+        return band.replace("I", "I_A_L")
+    else:
+        return band.replace("I", "i_a_l")
+
+
+def get_c20_band(band):
+    if band in ["I484", "I527"]:
+        return band.replace("I", "SC_IA")
+    else:
+        return band.replace("I", "SC_IB")
+
+
+def read_photspecfn(photspecfn):
+
+    bands = get_img_bands("suprime")
+    d = Table(fitsio.read(photspecfn, "CUSTOM"))
+    t = Table(fitsio.read(photspecfn, "PHOTINFO"))
+    for key in t.colnames:
+        newkey = key.upper()
+        for band in bands:
+            newkey = newkey.replace("I_A_L{}".format(band[1:]), band)
+        if newkey not in d.colnames:
+            d[newkey] = t[key]
+    return d
+
+
+# TODO: first match to e.g. ls-dr9.1.1., and use FLUX_G
+def get_clean_for_offsets(d, band, fmin=1, fmax=1000):
+
+    sel = d["BRICK_PRIMARY"].copy()
+    sel &= d["TYPE"] == "PSF"
+    sel &= d["SPECTRO_FIBERTOTFLUX_{}".format(band)] > fmin
+    sel &= d["SPECTRO_FIBERTOTFLUX_{}".format(band)] < fmax
+    sel &= d["SPECTRO_FIBERTOTFLUX_{}".format(band)] > (1000 / (12.15 * d["TSNR2_LRG"]))
+    return sel
+
+
+def get_ratios(d, band, fkey, offsets=None):
+
+    fratios = d["{}_{}".format(fkey, band)] / d["SPECTRO_FIBERTOTFLUX_{}".format(band)]
+
+    if offsets is not None:
+        fratios /= offsets
+
+    return fratios
+
+
+# gausspsfdepth: 5-sigma PSF detection depth in AB mag
+# depth_mag = -2.5 * log10(5 / sqrt(ivar))
+def ivar2mag(ivars):
+    return 22.5 - 2.5 * np.log10(5 / np.sqrt(ivars))
+
+
+def mag2ivar(mags):
+    # return 10 ** (+0.4 * 2 * (mags - 22.5)) / 5.
+    return (5 * 10 ** (+0.4 * (mags - 22.5))) ** 2
+
+
+# depths are (5sigma) mags
+# the ivar of an ivar-weighted mean is the sum of the ivars
+# https://en.wikipedia.org/wiki/Inverse-variance_weighting
+# so we first convert to ivar and sum 1/ivar
+# then convert back to mag
+#
+# brn_d : d cut on a brick
+def get_brn_perccd_gausspsfdepths(
+    brn_d, band, brn, rakey="TARGET_RA", deckey="TARGET_DEC"
+):
+
+    # ccds for the brick
+    brn_ccdfn = get_suprime_brn_ccdfn(brn)
+    brn_ccd_d = Table.read(brn_ccdfn)
+    sel = brn_ccd_d["filter"] == band.replace("I", "I-A-L")
+    brn_ccd_d = brn_ccd_d[sel]
+    brn_unqids = np.array(
+        [
+            "{}-{}".format(e, c)
+            for e, c in zip(brn_ccd_d["expnum"], brn_ccd_d["ccdname"])
+        ]
+    )
+
+    # all ccds (to grab ra0, ra1, etc)
+    annotated_ccdfn = get_get_suprime_annotated_ccdfn()
+    ccd_d = Table.read(annotated_ccdfn)
+    sel = ccd_d["filter"] == band.replace("I", "I-A-L")
+    ccd_d = ccd_d[sel]
+    unqids = np.array(
+        ["{}-{}".format(e, c) for e, c in zip(ccd_d["expnum"], ccd_d["ccdname"])]
+    )
+
+    # cut on ccds used in the brick
+    sel = np.in1d(unqids, brn_unqids)
+    ccd_d = ccd_d[sel]
+
+    # test all ccds
+    ccdnames = get_ccdnames()
+    nccd = len(ccdnames)
+    depths = np.zeros((len(brn_d), nccd), dtype=float)
+
+    for i in range(nccd):
+
+        jj = np.where(ccd_d["ccdname"] == ccdnames[i])[0]
+
+        for j in jj:
+
+            # TODO handle good_region..
+            # but ~ok to ignore, at worse it s ~50 pixels rejected
+            ra0, ra1, ra2, ra3 = (
+                ccd_d["ra0"][j],
+                ccd_d["ra1"][j],
+                ccd_d["ra2"][j],
+                ccd_d["ra3"][j],
+            )
+            dec0, dec1, dec2, dec3 = (
+                ccd_d["dec0"][j],
+                ccd_d["dec1"][j],
+                ccd_d["dec2"][j],
+                ccd_d["dec3"][j],
+            )
+
+            ccd_ras = [ra0, ra1, ra2, ra3, ra0]
+            ccd_decs = [dec0, dec1, dec2, dec3, dec0]
+
+            p = Path([(ra, dec) for ra, dec in zip(ccd_ras, ccd_decs)])
+
+            isccd_j = p.contains_points(
+                [(ra, dec) for ra, dec in zip(brn_d[rakey], brn_d[deckey])]
+            )
+
+            depths[isccd_j, i] += mag2ivar(ccd_d["gausspsfdepth"][j])
+
+        sel = depths[:, i] != 0
+        depths[sel, i] = ivar2mag(depths[sel, i])
+
+    return depths
+
+
+def get_perccd_gausspsfdepths(
+    d, band, brnkey="BRICKNAME", rakey="TARGET_RA", deckey="TARGET_DEC"
+):
+
+    ccdnames = get_ccdnames()
+    depths = np.zeros((len(d), len(ccdnames)), dtype=float)
+
+    for brn in np.unique(d[brnkey]):
+
+        sel = d[brnkey] == brn
+        depths[sel] = get_brn_perccd_gausspsfdepths(
+            d[sel], band, brn, rakey=rakey, deckey=deckey
+        )
+
+    return depths
+
+
+def add_offsets_keys(d, band, perccd_gausspsfdepths, perobj_offsets, clean_sel=None):
+
+    nccd = len(get_ccdnames())
+
+    # used in the process?
+    if clean_sel is not None:
+        key = "ISCLEAN_FOR_OFFSET_{}".format(band)
+        assert key not in d.colnames
+        d[key] = clean_sel
+
+    # per-ccd gausspsfdepth
+    key = "PERCCD_GAUSSPSFDEPTH_{}".format(band)
+    assert key not in d.colnames
+    d[key] = perccd_gausspsfdepths
+
+    # total gausspsfdepth
+    totdepths = np.zeros(len(d))
+    for i in range(nccd):
+        totdepths += mag2ivar(d["PERCCD_GAUSSPSFDEPTH_{}".format(band)][:, i])
+    sel = totdepths != 0
+    totdepths[sel] = ivar2mag(totdepths[sel])
+    key = "ALLCCD_GAUSSPSFDEPTH_{}".format(band)
+    assert key not in d.colnames
+    d[key] = totdepths
+
+    # per-object estimated offset
+    key = "OFFSET_{}".format(band)
+    assert key not in d.colnames
+    d[key] = perobj_offsets
+
+    return d
+
+
+def get_band_offsets(d, band, fkey, fmin=1, fmax=1000):
+
+    ccdnames = get_ccdnames()
+    nccd = len(ccdnames)
+
+    perccd_gausspsfdepths = get_perccd_gausspsfdepths(d, band)
+    assert perccd_gausspsfdepths.shape[1] == nccd
+
+    iv_ccds = mag2ivar(perccd_gausspsfdepths)
+    phot_fs = d["{}_{}".format(fkey, band)]
+    spec_fs = d["SPECTRO_FIBERTOTFLUX_{}".format(band)]
+
+    # test flux ratios within 0, 3
+    vals = np.arange(0, 3, 0.01).round(2)
+
+    # we initialize each ccd with the median offset for a clean sample
+    clean_sel = get_clean_for_offsets(d, band, fmin, fmax)
+    med_offset = np.nanmedian((spec_fs / phot_fs)[clean_sel])
+    ccd_offsets = med_offset + np.zeros(nccd)
+    log.info("initialize with ccd_offsets = {} for all ccds".format(med_offset))
+
+    # 10 steps should be sufficient to converge...
+    # in each loop, we iterate over the ccds one by one... simpler to code..
+    log.info("# BAND ITERATION {}".format("\t".join(ccdnames)))
+
+    for i_iter in range(10):
+
+        prev_ccd_offsets = ccd_offsets.copy()
+
+        for ccdnum in range(nccd):
+
+            ress = -99 + 0.0 * vals
+
+            for i in range(len(vals)):
+
+                ccd_offsets[ccdnum] = vals[i]
+
+                # per-obj. offset
+                perobj_offsets = (ccd_offsets * iv_ccds).sum(axis=1) / iv_ccds.sum(
+                    axis=1
+                )
+
+                # corrected phot_fs
+                corr_fs = spec_fs * perobj_offsets
+
+                # quantity to minimize
+                xs = np.abs(corr_fs / phot_fs - 1)
+
+                # taking the median for the clean sample
+                ress[i] = np.nanmedian(xs[clean_sel])
+
+            ccd_offsets[ccdnum] = vals[ress.argmin()]
+
+        log.info("{}\t{}\t{}".format(band, i_iter, "\t".join(ccd_offsets.astype(str))))
+
+        if np.all(ccd_offsets == prev_ccd_offsets):
+
+            log.info(
+                "reached convergence after {} iterations; stop here".format(i_iter + 1)
+            )
+            break
+
+        prev_ccd_offsets = ccd_offsets.copy()
+
+    # add few convenience columns to d
+    perobj_offsets = (ccd_offsets * iv_ccds).sum(axis=1) / iv_ccds.sum(axis=1)
+    d = add_offsets_keys(
+        d, band, perccd_gausspsfdepths, perobj_offsets, clean_sel=clean_sel
+    )
+
+    # now format the per-ccd offset into a Table()
+    d_band_offsets = Table()
+    d_band_offsets["CCDNAME"] = ccdnames
+    d_band_offsets["FILTER"] = band
+    d_band_offsets["OFFSET"] = ccd_offsets
+    d_band_offsets = d_band_offsets["FILTER", "CCDNAME", "OFFSET"]
+
+    return d, d_band_offsets
+
+
+def get_offsets(d, fkey, fmin=1, fmax=1000):
+
+    bands = get_img_bands("suprime")
+    all_d_band_offsets = []
+
+    for band in bands:
+
+        d, d_band_offsets = get_band_offsets(d, band, fkey, fmin=fmin, fmax=fmax)
+        all_d_band_offsets.append(d_band_offsets)
+
+    d_offsets = vstack(all_d_band_offsets)
+
+    return d, d_offsets
+
+
+def get_and_add_offsets_quants(
+    offsetsfn,
+    d,
+    fmin=1,
+    fmax=1000,
+    brnkey="BRICKNAME",
+    rakey="TARGET_RA",
+    deckey="TARGET_DEC",
+):
+
+    bands = get_img_bands("suprime")
+    ccdnames = get_ccdnames()
+
+    all_ccd_offsets = Table.read(offsetsfn)
+
+    for band in bands:
+
+        # estimated per-ccd offsets
+        ccd_offsets = []
+        for ccdname in ccdnames:
+            sel = (all_ccd_offsets["FILTER"] == band) & (
+                all_ccd_offsets["CCDNAME"] == ccdname
+            )
+            ccd_offset = all_ccd_offsets["OFFSET"][sel][0]
+            ccd_offsets.append(ccd_offset)
+        ccd_offsets = np.array(ccd_offsets)
+
+        # per-ccd quantities
+        perccd_gausspsfdepths = get_perccd_gausspsfdepths(
+            d, band, brnkey=brnkey, rakey=rakey, deckey=deckey
+        )
+        iv_ccds = mag2ivar(perccd_gausspsfdepths)
+
+        # add offsets columns to d
+        perobj_offsets = (ccd_offsets * iv_ccds).sum(axis=1) / iv_ccds.sum(axis=1)
+        d = add_offsets_keys(d, band, perccd_gausspsfdepths, perobj_offsets)
+
+    return d
+
+
+def apply_offsets(
+    tractorfn,
+    offsetsfn,
+    fkeys=[
+        "flux",
+        "fiberflux",
+        "fibertotflux",
+        "apflux",
+        "apflux_resid",
+        "apflux_blobresid",
+    ],
+):
+
+    bands = get_img_bands("suprime")
+
+    d = Table(fitsio.read(tractorfn))
+
+    # get offsets quantities
+    d = get_and_add_offsets_quants(
+        offsetsfn, d, brnkey="brickname", rakey="ra", deckey="dec"
+    )
+
+    # correct for the offsets
+    for band in bands:
+
+        for fkey in fkeys:
+
+            tband = band.replace("I", "i_a_l")
+            key = "{}_{}".format(fkey, tband)
+            if len(d[key].shape) == 2:
+                for i in range(d[key].shape[1]):
+                    d[key][:, i] /= d["OFFSET_{}".format(band)]
+            else:
+                d[key] /= d["OFFSET_{}".format(band)]
+
+    d.meta["MODIFKEY"] = ",".join(fkeys)
+
+    return d
+
+
+def plot_suprime_ccd(ax, band, ccdname, **kwargs):
+
+    annotated_ccdfn = get_get_suprime_annotated_ccdfn()
+    ccd_d = Table.read(annotated_ccdfn)
+
+    sel = ccd_d["filter"] == band.replace("I", "I-A-L")
+    sel &= ccd_d["ccdname"] == ccdname
+    ii = np.where(sel)[0]
+
+    for i in ii:
+
+        ras = [
+            ccd_d["ra0"][i],
+            ccd_d["ra1"][i],
+            ccd_d["ra2"][i],
+            ccd_d["ra3"][i],
+            ccd_d["ra0"][i],
+        ]
+        decs = [
+            ccd_d["dec0"][i],
+            ccd_d["dec1"][i],
+            ccd_d["dec2"][i],
+            ccd_d["dec3"][i],
+            ccd_d["dec0"][i],
+        ]
+        ax.plot(ras, decs, **kwargs)
+
+
+# name : orig, offsets, corrected
+def plot_indiv_band(
+    ax,
+    axh,
+    d,
+    band,
+    name,
+    ccdname=None,
+    sample_label=None,
+    vmin=0.8,
+    vmax=1.2,
+    alpha=0.75,
+):
+
+    names = ["ORIG", "OFFSETS", "CORR"]
+    assert name in names
+
+    clean_sel = d["CLEAN_{}".format(band)]
+
+    true_fs = d["TRUE_FLUX_{}".format(band)].copy()
+    orig_fs = d["ORIG_FLUX_{}".format(band)].copy()
+    corr_fs = d["CORR_FLUX_{}".format(band)].copy()
+    offsets = orig_fs / corr_fs
+
+    ratios = {
+        "ORIG": orig_fs / true_fs,
+        "OFFSETS": offsets,
+        "CORR": corr_fs / true_fs,
+    }
+
+    # median values
+    medians = {_: np.nanmedian(ratios[_][clean_sel]).round(2) for _ in names}
+
+    # divide by median values
+    for _ in names:
+        ratios[_] /= medians[_]
+
+    norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
+    # cmap = matplotlib.cm.viridis
+    cmap = matplotlib.cm.coolwarm
+
+    # offsets: plot all objects
+    if name == "OFFSETS":
+
+        title = "{}\nAll objects ({})\ncase = {} (median={})".format(
+            band, len(d), name, medians[name]
+        )
+        sc = ax.scatter(
+            d["RA"],
+            d["DEC"],
+            c=ratios["OFFSETS"],
+            s=1,
+            alpha=alpha,
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            zorder=0,
+            rasterized=True,
+        )
+        clabel = "Estimated OFFSETS / median"
+
+    # orig / corrected: plot clean selection
+    else:
+
+        if clean_sel.sum() < 5000:
+            s = 10
+        elif clean_sel.sum() < 10000:
+            s = 5
+        else:
+            s = 1
+
+        if sample_label is None:
+            sample_label2 = "Some sample"
+        else:
+            sample_label2 = sample_label
+        title = "{}\n{} ({})\ncase = {} (median = {})".format(
+            band,
+            sample_label2,
+            clean_sel.sum(),
+            name,
+            medians[name],
+        )
+        sc = ax.scatter(
+            d["RA"][clean_sel],
+            d["DEC"][clean_sel],
+            c=ratios[name][clean_sel],
+            s=s,
+            alpha=alpha,
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            zorder=0,
+            rasterized=True,
+        )
+        clabel = "{}/TRUE flux ratio / median".format(name)
+
+    cbar = plt.colorbar(mappable=sc, ax=ax, extend="both")
+    cbar.mappable.set_clim([vmin, vmax])
+    cbar.set_label(clabel)
+
+    # suprime ccds
+    if ccdname is not None:
+        color, lw, ls, alpha, zorder = "k", 1, "-", 1, 1
+        if ccdname == "all":
+            ccdnames = get_ccdnames()
+            lw = 0.2
+            ax.plot(
+                np.nan,
+                np.nan,
+                color=color,
+                lw=lw,
+                ls=ls,
+                alpha=alpha,
+                zorder=zorder,
+                label="All CCDs",
+            )
+        else:
+            ccdnames = [ccdname]
+            ax.plot(
+                np.nan,
+                np.nan,
+                color=color,
+                lw=lw,
+                ls=ls,
+                alpha=alpha,
+                zorder=zorder,
+                label="{} CCD".format(ccdname),
+            )
+        for ccdname in ccdnames:
+            plot_suprime_ccd(
+                ax,
+                band,
+                ccdname,
+                color=color,
+                lw=lw,
+                ls=ls,
+                alpha=alpha,
+                zorder=zorder,
+            )
+
+    ax.set_title(title)
+    ax.set_xlabel("R.A [deg]")
+    ax.set_ylabel("Dec. [deg]")
+    ax.grid()
+    ax.set_axisbelow(True)
+    ax.set_xlim(150.95, 149.3)
+    ax.set_ylim(1.35, 3.05)
+    if ccdname is not None:
+        ax.legend(loc=2)
+
+    # hist
+    if axh is not None:
+        histtypes = {"ORIG": "step", "CORR": "stepfilled"}
+        colors = {"ORIG": "k", "CORR": "g"}
+        alphas = {"ORIG": 1.0, "CORR": 0.5}
+        zorders = {"ORIG": 1, "CORR": 0}
+        bins = np.linspace(0.0, 2.0, 101)
+        _ = axh.hist(
+            ratios[name][clean_sel],
+            bins=bins,
+            density=True,
+            histtype=histtypes[name],
+            color=colors[name],
+            alpha=alphas[name],
+            zorder=zorders[name],
+            label="Flux ratio = {}/TRUE (median={})".format(name, medians[name]),
+        )
+        # if corrected: also plot orig
+        if name == "CORR":
+            _ = axh.hist(
+                ratios["ORIG"][clean_sel],
+                bins=bins,
+                density=True,
+                histtype=histtypes["ORIG"],
+                color=colors["ORIG"],
+                alpha=alphas["ORIG"],
+                zorder=zorders["ORIG"],
+                label="Flux ratio = {}/TRUE (median={})".format(
+                    "ORIG", medians["ORIG"]
+                ),
+            )
+
+        axh.set_xlabel("Flux ratio / median")
+        axh.set_ylabel("Norm. counts")
+        axh.grid()
+        axh.set_axisbelow(True)
+        axh.set_xlim(bins[0], bins[-1])
+        axh.set_ylim(0, 7)
+        axh.legend(loc=2)
+
+
+def plot_offsets_band(outpng, d, band, ccdname=None, sample_label=None):
+
+    fig = plt.figure(figsize=(20, 10))
+    gs = gridspec.GridSpec(2, 3, wspace=0.25, hspace=0.2)
+
+    for iy, name in enumerate(["ORIG", "OFFSETS", "CORR"]):
+
+        ax = fig.add_subplot(gs[0, iy])
+
+        if name == "OFFSETS":
+
+            axh = None
+            axlab = fig.add_subplot(gs[1, iy])
+            axlab.axis("off")
+            for ytxt, txt in zip(
+                [0.8, 0.7, 0.6],
+                [
+                    "TRUE = {}".format(d.meta["TRUE"]),
+                    "ORIG = {}".format(d.meta["ORIG"]),
+                    "CORR = {} / OFFSETS".format(d.meta["ORIG"]),
+                ],
+            ):
+                axlab.text(0.05, ytxt, txt, fontsize=15, transform=axlab.transAxes)
+
+        else:
+
+            axh = fig.add_subplot(gs[1, iy])
+        plot_indiv_band(
+            ax, axh, d, band, name, ccdname=ccdname, sample_label=sample_label
+        )
+
+    plt.savefig(outpng, bbox_inches="tight")
+    plt.close()
+
+
+def plot_offsets(d, outpngroot, ccdnames=[None], sample_label=None):
+
+    bands = get_img_bands("suprime")
+
+    for band in bands:
+
+        for ccdname in ccdnames:
+            outpng = "{}-{}.png".format(outpngroot, band)
+            if ccdname is not None:
+                outpng = outpng.replace(".png", "-{}.png".format(ccdname))
+            log.info("plot {}".format(outpng))
+            plot_offsets_band(
+                outpng, d, band, ccdname=ccdname, sample_label=sample_label
+            )
+
+
+# sample = star or laelbg
+def get_d_for_plot_offsets(outphotspecfn, fkey, sample):
+
+    assert sample in ["star", "laelbg"]
+
+    if sample == "laelbg":
+
+        fn = os.path.join(
+            os.getenv("DESI_ROOT"),
+            "survey",
+            "fiberassign",
+            "special",
+            "tertiary",
+            "0026",
+            "tertiary-targets-0026.fits",
+        )
+        t = Table.read(fn)
+        sel = (t["SUPRIME"]) | (t["LAE_SUBARU"])
+        tids = t["TARGETID"][sel]
+
+    bands = get_img_bands("suprime")
+    d = Table(fitsio.read(outphotspecfn))
+
+    myd = Table()
+    myd["RA"], myd["DEC"] = d["RA"].copy(), d["DEC"].copy()
+
+    for band in bands:
+
+        if sample == "star":
+
+            myd["CLEAN_{}".format(band)] = d[
+                "ISCLEAN_FOR_OFFSET_{}".format(band)
+            ].copy()
+
+        if sample == "laelbg":
+
+            myd["CLEAN_{}".format(band)] = np.in1d(d["TARGETID"], tids)
+
+        myd["TRUE_FLUX_{}".format(band)] = d[
+            "SPECTRO_FIBERTOTFLUX_{}".format(band)
+        ].copy()
+        myd["ORIG_FLUX_{}".format(band)] = d["{}_{}".format(fkey, band)].copy()
+        myd["CORR_FLUX_{}".format(band)] = (
+            d["{}_{}".format(fkey, band)] / d["OFFSET_{}".format(band)]
+        )
+
+    myd.meta["TRUE"] = "SPECTRO_FIBERTOTFLUX"
+    myd.meta["ORIG"] = "TRACTOR {}".format(fkey)
+
+    return myd
+
+
+# m = 22.5 - 2.5 * log10(f_nmg)
+#   = 23.9 - 2.5 * log10(f_uJy)
+# f_nmg = 10 ** (-0.4 * (23.9 - 22.5)) * f_uJy
+def flux_uJy2nmg(fs):
+    return 10 ** (-0.4 * (23.9 - 22.5)) * fs
+
+
+def get_match_cosmos2020(tractorfn, offsetsfn, fmin=1, fmax=1000):
+
+    bands = get_img_bands("suprime")
+
+    # tractor
+    t = Table(fitsio.read(tractorfn))
+    sel = t["brick_primary"]
+    t = t[sel]
+
+    # compute offsets
+    t = apply_offsets(tractorfn, offsetsfn)
+
+    # cosmos2020 ACS stars
+    c20fn = get_cosmos2020_fn("cosmos_yr2")
+    c20 = Table(fitsio.read(c20fn))
+
+    # match
+    iit, iic20, _, _, _ = match_coord(
+        t["ra"], t["dec"], c20["ALPHA_J2000"], c20["DELTA_J2000"], search_radius=1.0
+    )
+    t, c20 = t[iit], c20[iic20]
+
+    # store relevant columns in a Table
+    d = Table()
+    d["RA"], d["DEC"] = t["ra"], t["dec"]
+    d["ACS_MU_CLASS"] = c20["ACS_MU_CLASS"]
+
+    for band in bands:
+
+        tband = get_tractor_band(band, uppercase=False)
+        d["ORIG_FLUX_{}".format(band)] = (
+            t["flux_{}".format(tband)] * t["OFFSET_{}".format(band)]
+        )
+        d["CORR_FLUX_{}".format(band)] = t["flux_{}".format(tband)]
+
+        c20band = get_c20_band(band)
+        d["TRUE_FLUX_{}".format(band)] = flux_uJy2nmg(c20["{}_FLUX".format(c20band)])
+
+        clean_sel = d["ACS_MU_CLASS"] == 2
+        clean_sel &= d["TRUE_FLUX_{}".format(band)] > fmin
+        clean_sel &= d["TRUE_FLUX_{}".format(band)] < fmax
+        d["CLEAN_{}".format(band)] = clean_sel
+
+    d.meta["TRUE"] = "COSMOS2020 FLUX"
+    d.meta["ORIG"] = "TRACTOR FLUX"
+
+    return d

--- a/py/desihizmerge/suprime_photspec_io.py
+++ b/py/desihizmerge/suprime_photspec_io.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python
+
+import os
+import fitsio
+from glob import glob
+import tempfile
+from speclite import filters as speclite_filters
+import numpy as np
+from astropy.table import Table, vstack, hstack
+from astropy.io import fits
+from astropy import units
+from desispec.io import read_spectra, write_spectra
+from desispec.coaddition import coadd_cameras, coadd_fibermap
+from desispec.spectra import stack as spectra_stack
+from desiutil.log import get_logger
+from desihizmerge.hizmerge_io import match_coord
+
+
+log = get_logger()
+
+
+def get_tractor_match(d, tractorfn):
+
+    t = Table(fitsio.read(tractorfn))
+
+    for key in t.colnames:
+
+        t[key].name = key.upper()
+
+    # no duplicates here..
+    iid, iit, _, _, _ = match_coord(
+        d["TARGET_RA"], d["TARGET_DEC"], t["RA"], t["DEC"], search_radius=1.0
+    )
+    log.info(
+        "match {}/{} unique TARGETIDs".format(iid.size, np.unique(d["TARGETID"]).size)
+    )
+
+    # handle duplicated TARGETIDs
+    sel = np.in1d(d["TARGETID"], d["TARGETID"][iid])
+    match_d = d[sel]
+    match_t = Table()
+
+    for key in t.colnames:
+
+        if len(t[key].shape) == 1:
+
+            match_t[key] = np.zeros_like(t[key], shape=(sel.sum(),))
+
+        elif len(t[key].shape) == 2:
+
+            match_t[key] = np.zeros_like(t[key], shape=(sel.sum(), t[key].shape[1]))
+
+        else:
+
+            msg = "unexpected t[{}].shape={}".format(key, t[key].shape)
+            log.error(msg)
+            raise ValueError(msg)
+
+    for i, it in zip(iid, iit):
+
+        sel = match_d["TARGETID"] == d["TARGETID"][i]
+
+        for key in t.colnames:
+
+            if len(t[key].shape) == 1:
+
+                match_t[key][sel] = t[key][it]
+
+            if len(t[key].shape) == 2:
+
+                match_t[key][sel, :] = t[key][it, :]
+
+    assert np.all(match_t["RA"] != 0.0)
+    log.info(
+        "returning tables with {} rows ({} unique TARGETIDs)".format(
+            len(match_d), iid.size
+        )
+    )
+
+    return match_d, match_t
+
+
+def get_filts(bands, waves):
+
+    filtdir = os.path.join(
+        os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", "suprime", "filt"
+    )
+    myfilts = {}
+
+    for band in bands:
+
+        filtfn = os.path.join(
+            filtdir, "Subaru_Suprime.{}.dat".format(band.replace("I", "IB"))
+        )
+        d = Table.read(filtfn, format="ascii.commented_header")
+        # d["WAVE"] is in nm
+        # let s convert to A, and interpolate on the DESI waves
+        myfilts[band] = {}
+        myfilts[band]["TRANS"] = np.interp(
+            waves, d["WAVE"], d["TRANSMISSION"], left=0, right=0
+        )
+
+    return myfilts
+
+
+def get_speclite_filts(bands, waves):
+
+    myfilts = get_filts(bands, waves)
+
+    # use band.lower() because speclite doesn t like e.g. "I427"...
+    tmp_speclite_dir = tempfile.mkdtemp()
+
+    for band in bands:
+
+        tmp_filt = speclite_filters.FilterResponse(
+            wavelength=waves * units.Angstrom,
+            response=myfilts[band]["TRANS"],
+            meta=dict(group_name="suprime", band_name=band.lower()),
+        )
+        tmp_name = tmp_filt.save(tmp_speclite_dir)
+
+    # now read them in
+    speclite_filts = {
+        band: speclite_filters.load_filter("suprime-{}".format(band.lower()))
+        for band in bands
+    }
+
+    return speclite_filts
+
+
+# d: CUSTOM
+def get_spectro_flux(bands, d, waves, fluxs):
+
+    speclite_filts = get_speclite_filts(bands, waves)
+
+    nspec = fluxs.shape[0]
+    spec_mags = {band: np.zeros(nspec) for band in bands}
+
+    for i in range(nspec):
+        tmpfs = fluxs[i].copy()
+        tmpfs *= 1e-17
+        tmpfs *= d["MEAN_PSF_TO_FIBER_SPECFLUX"][i]
+
+        for band in bands:
+
+            spec_mags[band][i] = speclite_filts[band].get_ab_magnitude(
+                tmpfs * units.erg / (units.cm**2 * units.s * units.Angstrom),
+                waves * units.Angstrom,
+            )
+
+    spec_fluxs = {band: 10 ** (-0.4 * (spec_mags[band] - 22.5)) for band in bands}
+
+    return spec_fluxs
+
+
+def process_fn(d, t, rrfn, bands):
+
+    cofn = rrfn.replace("redrock", "coadd")
+    s = read_spectra(cofn)
+    fm = s.fibermap
+    sel = d["FN"] == rrfn
+    log.info("{}\t{}".format(sel.sum(), rrfn))
+
+    if sel.sum() == 0:
+
+        msg = "{}\tsel.sum() = 0; this shouldn t happen".format(rrfn)
+        log.error(msg)
+        raise ValueError(msg)
+
+    s = s.select(targets=d["TARGETID"][sel])
+    assert np.all(s.fibermap["TARGETID"] == d["TARGETID"][sel])
+    s = coadd_cameras(s)
+    myd, myt = d[sel], t[sel]
+
+    spec_fluxs = get_spectro_flux(bands, d, s.wave["brz"], s.flux["brz"])
+
+    for band in bands:
+
+        myd["SPECTRO_FIBERTOTFLUX_{}".format(band)] = spec_fluxs[band]
+
+    return (s, myd, myt)
+
+
+# d: CUSTOM table
+# t: PHOTINFO table
+def get_unq_spectra(d, t, waves, fluxs, ivars, bands):
+
+    orig_d, orig_t = d.copy(), t.copy()
+    orig_fluxs, orig_ivars = fluxs.copy(), ivars.copy()
+
+    # cut on COADD_FIBERSTATUS = 0
+    sel = d["COADD_FIBERSTATUS"] == 0
+    d, t = d[sel], t[sel]
+    fluxs, ivars = fluxs[sel, :], ivars[sel, :]
+
+    #
+    unq_tids, ii, counts = np.unique(
+        d["TARGETID"], return_index=True, return_counts=True
+    )
+    ntid = unq_tids.size
+
+    unq_d = Table()
+
+    for key in ["TARGETID", "TARGET_RA", "TARGET_DEC", "COADD_FIBERSTATUS"]:
+
+        unq_d[key] = d[key][ii]
+
+    unq_d["NSPEC"] = counts
+    unq_d["MEAN_PSF_TO_FIBER_SPECFLUX"] = 0.0
+    tsnr2_keys = [key for key in d.colnames if "TSNR2" in key]
+
+    for key in tsnr2_keys:
+
+        unq_d[key] = 0.0
+
+    unq_t = Table()
+
+    for key in t.colnames:
+
+        if len(t[key].shape) == 1:
+
+            unq_t[key] = t[key][ii]
+
+        if len(t[key].shape) == 2:
+
+            unq_t[key] = t[key][ii, :]
+
+    nwave = waves.size
+    unq_fluxs = np.zeros((ntid, nwave), dtype=float)
+    unq_ivars = np.zeros((ntid, nwave), dtype=float)
+
+    # rows with counts = 1
+    sel = counts == 1
+    unq_fluxs[sel, :] = fluxs[ii[sel], :]
+    unq_ivars[sel, :] = ivars[ii[sel], :]
+    unq_d["MEAN_PSF_TO_FIBER_SPECFLUX"][sel] = d["MEAN_PSF_TO_FIBER_SPECFLUX"][ii[sel]]
+
+    for key in tsnr2_keys:
+
+        unq_d[key][sel] = d[key][ii[sel]]
+
+    # rows with counts > 1
+    # tsnr2: summing
+
+    for i in np.where(counts > 1)[0]:
+
+        jj = np.where(d["TARGETID"] == unq_d["TARGETID"][i])[0]
+        log.info("{}\t{}".format(jj.size, unq_d["TARGETID"][i]))
+
+        for j in jj:
+
+            unq_fluxs[i] += fluxs[j] * ivars[j]
+            unq_ivars[i] += ivars[j]
+
+        unq_fluxs[i] /= unq_ivars[i]
+        unq_d["MEAN_PSF_TO_FIBER_SPECFLUX"][i] = d["MEAN_PSF_TO_FIBER_SPECFLUX"][
+            jj
+        ].mean()
+
+        for key in tsnr2_keys:
+
+            unq_d[key][i] = d[key][jj].sum()
+
+    # SPECTRO_FIBERTOTFLUX
+    spec_fluxs = get_spectro_flux(bands, unq_d, waves, unq_fluxs)
+
+    for band in bands:
+
+        unq_d["SPECTRO_FIBERTOTFLUX_{}".format(band)] = spec_fluxs[band]
+
+    d, t = orig_d, orig_t
+    fluxs, ivars = orig_fluxs, orig_ivars
+
+    return unq_fluxs, unq_ivars, unq_d, unq_t
+
+
+def build_hs(s, d, t):
+
+    hs = fits.HDUList()
+
+    # header
+    h = fits.PrimaryHDU()
+    hs.append(h)
+
+    # images
+    for ext, bunit in zip(
+        ["wave", "flux", "ivar"],
+        [
+            "Angstrom",
+            "10**-17 erg/(s cm2 Angstrom)",
+            "10**+34 (s2 cm4 Angstrom2) / erg2",
+        ],
+    ):
+
+        h = fits.ImageHDU(name="BRZ_{}".format(ext.upper()))
+
+        if bunit is not None:
+
+            h.header["BUNIT"] = bunit
+
+        h.data = eval("s.{}['brz']".format(ext))
+        hs.append(h)
+
+    # tables
+    for extd, extname in zip(
+        [s.fibermap, s.scores, d, t],
+        ["FIBERMAP", "SCORES", "CUSTOM", "PHOTINFO"],
+    ):
+
+        h = fits.convenience.table_to_hdu(extd)
+        h.header["EXTNAME"] = extname
+        hs.append(h)
+
+    return hs
+
+
+def build_unq_hs(waves, unq_fluxs, unq_ivars, unq_d, unq_t):
+
+    hs = fits.HDUList()
+
+    # header
+    h = fits.PrimaryHDU()
+    hs.append(h)
+
+    # images
+    for ext, extd, bunit in zip(
+        ["wave", "flux", "ivar"],
+        [waves, unq_fluxs, unq_ivars],
+        [
+            "Angstrom",
+            "10**-17 erg/(s cm2 Angstrom)",
+            "10**+34 (s2 cm4 Angstrom2) / erg2",
+        ],
+    ):
+
+        h = fits.ImageHDU(name="BRZ_{}".format(ext.upper()))
+
+        if bunit is not None:
+
+            h.header["BUNIT"] = bunit
+
+        h.data = extd
+        hs.append(h)
+
+    # tables
+    for extd, extname in zip(
+        [unq_d, unq_t],
+        ["CUSTOM", "PHOTINFO"],
+    ):
+
+        h = fits.convenience.table_to_hdu(extd)
+        h.header["EXTNAME"] = extname
+        hs.append(h)
+
+    return hs


### PR DESCRIPTION
This PR adds the files used to compute the overall and per-ccd offsets in the suprime tractor catalogs.
This code was used to diagnose the issue in the first reduction (2023-03-07), and validate the last reduction (2023-10-25).
In the end, the last set of tractor catalogs (with no offsets) can be used to have the correct photometry.

Usage:
A pre-requisite is a compilation of the DESI observations in COSMOS. Then code proceeds in two steps:
- match all DESI observations to the tractor photometry, and compute for those the `SPEC_FIBERTOTFLUX` for the suprime passbands, ie the DESI spectra convolved with the passbands; this is considered as the "truth";
- estimate the offsets with comparing the tractor `FIBERTOTFLUX` against the `SPEC_FIBERTOTFLUX` and assuming a constant offset per {band,ccd}.

Example of running the code for the 2023-10-25 reduction:

```
OFFSETDIR=/global/cfs/cdirs/desi/users/raichoor/laelbg/suprime/offsets/phot-redux-20231025
TRACTORFN=/global/cfs/cdirs/desi/users/raichoor/laelbg/suprime/phot/Subaru_tractor_forced_all-redux-20231025.fits

; match DESI obs. to tractor catalogs (from an interactive node)
desi_suprime_photspec --outdir $OFFSETDIR/spec --step all --tractorfn $TRACTORFN --numproc 64

; coadds the DESI spectra for repeat observations, hence having high-snr spectra for a unique list of TARGETIDs
desi_suprime_photspec --outdir $OFFSETDIR/spec --step unq --tractorfn $TRACTORFN

; compute the per-ccd offsets
desi_suprime_photoff --outdir $OFFSETDIR --photspecfn $OFFSETDIR/spec/cosmos-desi-thru20230416-cumulhpx-spectra-unq.fits --step compute --tractorfn $TRACTORFN

; plots
desi_suprime_photoff --outdir $OFFSETDIR --photspecfn $OFFSETDIR/spec/cosmos-desi-thru20230416-cumulhpx-spectra-unq.fits --step plot_stars --tractorfn $TRACTORFN
desi_suprime_photoff --outdir $OFFSETDIR --photspecfn $OFFSETDIR/spec/cosmos-desi-thru20230416-cumulhpx-spectra-unq.fits --step plot_cosmos2020 --tractorfn $TRACTORFN
```

Context / History:
- the first reduction on 2023-03-07 (`$DESI_ROOT/users/dstn/suprime`) had significant offsets in I427 and I527, along with an additional signficant offset for the `DET0` ccd on top of that
- this code was developed to diagnosis + map those
- then another reduction was done on 2023-10-19 (`$DESI_ROOT/users/dstn/suprime-rerun`), which took out the per-ccd differences; but the overall offsets in I427 and I527 were still there
- then another reduction was done on 2023-10-24 (`$DESI_ROOT/users/dstn/suprime-rerun-2`), with using 8 DESI STD stars (`DESI_ROOT/users/raichoor/laelbg/suprime/offsets/suprime-std-for-photcalib.{fits,pdf}) to calibrate the overall photometric offset from PS1
- and a last run was done on 2023-10-25 with adding the HSC-forced photometry (in `$DESI_ROOT/users/dstn/suprime-rerun-2`).

The discussions took place:
- on decam-chatter, e.g. decam-chatter 17829;
- slides at the imaging telecon on Oct. 18, 2023: https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=7913;
- on slack imaging channel, starting here: https://desisurvey.slack.com/archives/C027M1AF31C/p1697652929548349.
