### PR TITLE
Angclust + cleaning

### DIFF
--- a/bin/desi_hiz_angclust
+++ b/bin/desi_hiz_angclust
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+
+import os
+import numpy as np
+from astropy.table import Table
+from desiutil.log import get_logger
+from desiutil.redirect import stdouterr_redirected
+from desihizmerge.hizmerge_io import (
+    allowed_imgs,
+    get_img_dir,
+    get_img_bands,
+)
+from desihizmerge.angclust_io import (
+    allowed_fields,
+    get_angclust_targs,
+    add_vi,
+)
+from argparse import ArgumentParser
+
+log = get_logger()
+
+
+def parse():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--outfn",
+        help="output fits filename (default=get_img_dir(img)/phot/{img}-{band}-{field}-for-angclust.fits)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--img",
+        help="imaging used for target selection (default=odin)",
+        choices=allowed_imgs,
+        type=str,
+        default="odin",
+    )
+    parser.add_argument(
+        "--band",
+        help="filter used for target selection (default=N501)",
+        type=str,
+        default="N501",
+    )
+    parser.add_argument(
+        "--field",
+        help="considered field (default=cosmos)",
+        choices=allowed_fields,
+        type=str,
+        default="cosmos",
+    )
+    parser.add_argument(
+        "--mergefn",
+        help="path to the desi-{img}.fits file (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--log-stdout",
+        "--log_stdout",
+        action="store_true",
+        help="log to stdout instead of redirecting to a file",
+    )
+    parser.add_argument(
+        "--overwrite",
+        help="overwrite files",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    assert args.img in allowed_imgs
+    assert args.band in get_img_bands(args.img)
+    assert args.field in allowed_fields
+
+    if args.outfn is None:
+        args.outfn = os.path.join(
+            get_img_dir(args.img),
+            "phot",
+            "{}-{}-{}-for-angclust.fits".format(args.img, args.band, args.field),
+        )
+    for kwargs in args._get_kwargs():
+        log.info("{}\t{}".format(kwargs[0], kwargs[1]))
+    return args
+
+
+def main():
+
+    for kwargs in args._get_kwargs():
+        log.info("{}\t{}".format(kwargs[0], kwargs[1]))
+
+    d = get_angclust_targs(args.img, args.band)
+    add_vi(d, args.img, args.band, args.mergefn)
+    d.write(args.outfn, overwrite=args.overwrite)
+
+
+if __name__ == "__main__":
+
+    args = parse()
+
+    assert args.outfn.split(os.path.extsep)[-1] == "fits"
+
+    outlog = args.outfn.replace(".fits", ".log")
+
+    if (os.path.isfile(args.outfn)) & (~args.overwrite):
+
+        msg = "{} exists and args.overwrite=False".format(args.outfn)
+        log.error(msg)
+        raise ValueError(msg)
+
+    if args.log_stdout:
+
+        main()
+
+    else:
+
+        with stdouterr_redirected(to=outlog):
+
+            main()

--- a/bin/desi_hiz_merge
+++ b/bin/desi_hiz_merge
@@ -9,6 +9,7 @@ from desiutil.redirect import stdouterr_redirected
 from desihizmerge.hizmerge_io import (
     print_config_infos,
     allowed_imgs,
+    get_img_dir,
     get_img_cases,
     get_img_bands,
     get_img_infos,
@@ -93,9 +94,7 @@ def main():
         log.info("{}\t{}".format(kwargs[0], kwargs[1]))
 
     bands = get_img_bands(args.img)
-    photdir = os.path.join(
-        os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", args.img, "phot"
-    )
+    photdir = os.path.join(get_img_dir(args.img), "phot")
 
     log.info("")
     log.info("bands\t= {}".format(bands))

--- a/py/desihizmerge/angclust_io.py
+++ b/py/desihizmerge/angclust_io.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+
+import os
+import fitsio
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table
+from desiutil.log import get_logger
+from desihizmerge.hizmerge_io import (
+    allowed_imgs,
+    get_img_bands,
+    get_phot_fns,
+    get_ext_coeffs,
+)
+
+log = get_logger()
+
+allowed_fields = ["cosmos", "xmmlss"]
+
+
+def get_angclust_targs(img, band):
+    """
+    Create the catalog for angular clustering used by MJW
+
+    Args:
+        img: element from allowed_imgs (str)
+        band: filter to consider (str)
+
+    Returns:
+        d: Table() with the selected photometric targets (astropy Table())
+
+    Notes:
+        ODIN/N501:
+            - reproducing AD "Selection3" sample
+            - tested on Nov. 16, 2023 against:
+                fn = "/pscratch/sd/m/mwhite/AnalyzeLAE/odin/odin_lae_cosmos_N501.fits"
+                d = Table.read(fn)
+                d = d[d["Selection3"] == 1]
+    """
+
+    assert img in allowed_imgs
+    assert band in get_img_bands(img)
+
+    # odin/n501
+    if (img == "odin") & (band == "N501"):
+
+        # for odin/n501, cosmos_yr1 and cosmos_yr2 used the same target catalog
+        fn = get_phot_fns(img, "cosmos_yr1", band)[0]
+        d = Table(fitsio.read(fn))
+        log.info("read {} rows from {}".format(len(d), fn))
+
+        # mags
+        ext_coeffs = get_ext_coeffs(img)
+        n501_mags = (
+            22.5
+            - 2.5 * np.log10(d["FLUX_N501"])
+            - ext_coeffs["ODIN"]["N501"] * d["EBV"]
+        )
+        n673_mags = (
+            22.5
+            - 2.5 * np.log10(d["FLUX_N673"])
+            - ext_coeffs["ODIN"]["N673"] * d["EBV"]
+        )
+
+        # cut on AD "Selection3"
+        cc = [-60.5, 5.5, -0.125]
+        cc2 = [-16.375, 0.6875]
+        sel = d["PRIORITY"] == 1
+        sel &= n501_mags >= 18
+        sel &= (
+            n501_mags - n673_mags <= cc[0] + cc[1] * n501_mags + cc[2] * n501_mags**2
+        )
+        sel &= n501_mags - n673_mags <= cc2[0] + cc2[1] * n501_mags
+
+        d = d[sel]
+
+        log.info("select {}/{} rows".format(sel.sum(), sel.size))
+
+    return d
+
+
+def add_vi(d, img, band, mergefn):
+    """
+    Adds the VI informations.
+
+    Args:
+        d: Table() with the selected photometric targets (astropy Table())
+        img: element from allowed_imgs (str)
+        band: filter to consider (str)
+        mergefn: full path to the desi-{img}.fits file (str)
+
+    Returns:
+        d: same as input, but with additional VI columns
+            (VI, VI_Z, VI_QUALITY, VI_SPECTYPE)
+
+    Notes:
+        A MERGEFN keyword is also added to d.meta.
+    """
+
+    assert img in allowed_imgs
+    assert band in get_img_bands(img)
+
+    # unqids: for matching
+    # pextname: for suprime, we will likely use PHOTV2INFO
+    if img == "odin":
+        pextname = "PHOTINFO"
+        unqids = np.array(
+            ["{}-{}".format(b, o) for b, o in zip(d["BRICKNAME"], d["OBJID"])]
+        )
+
+    # read vi info
+    s = Table(fitsio.read(mergefn, "SPECINFO"))
+    p = Table(fitsio.read(mergefn, pextname))
+    log.info("read {} rows from {}".format(len(s), mergefn))
+
+    # cut on VI-ed rows + some per-img custom cuts
+    # + rename s["TARGETID"] => s["VI_TARGETID"]
+    sel = s["VI"]
+    sel &= s[band]
+    if img == "odin":
+        sel &= np.in1d(s["CASE"].astype(str), ["cosmos_yr1", "cosmos_yr2"])
+    s, p = s[sel], p[sel]
+    s["TARGETID"].name = "VI_TARGETID"
+    log.info(
+        "cut on {}/{} rows with VI + some per-img custom cuts".format(
+            sel.sum(), sel.size
+        )
+    )
+
+    # unqids
+    if img == "odin":
+        p["UNQID"] = np.array(
+            ["{}-{}".format(b, o) for b, o in zip(p["BRICKNAME"], p["OBJID"])]
+        )
+
+    # initialize columns to fill
+    keys = ["VI", "VI_TARGETID", "VI_Z", "VI_QUALITY", "VI_SPECTYPE", "EFFTIME_SPEC"]
+    for key in keys:
+        d[key] = np.zeros_like(s[key], shape=(len(d),))
+
+    # fill (not many rows, so just brutal loop, no fancy method...)
+    for i, unqid in enumerate(unqids):
+        jj = np.where(p["UNQID"] == unqid)[0]
+        assert jj.size <= 1
+        if jj.size == 1:
+            j = jj[0]
+            for key in keys:
+                d[key][i] = s[key][j]
+    log.info("filled {}/{} rows with VI infos".format(d["VI"].sum(), len(d)))
+
+    # add info in header
+    d.meta["MERGEFN"] = mergefn
+
+    return d

--- a/py/desihizmerge/hizmerge_clauds.py
+++ b/py/desihizmerge/hizmerge_clauds.py
@@ -13,7 +13,7 @@ from desitarget.targetmask import desi_mask
 from desitarget.geomask import match_to
 from desiutil.log import get_logger
 from desihizmerge.hizmerge_io import (
-    default_photdir,
+    get_img_dir,
     get_img_bands,
     match_coord,
     get_init_infos,
@@ -391,9 +391,9 @@ def get_clauds_phot_infos(case, d, photdir=None, v2=None):
         claudsids: the CLAUDS ID (np.array of int)
         targfns:
     """
-    if photdir == None:
+    if photdir is None:
 
-        photdir = default_photdir
+        photdir = os.path.join(get_img_dir("clauds"), "phot")
 
     # initialize columns we will fill
     claudsids = np.zeros(len(d), dtype=int)

--- a/py/desihizmerge/hizmerge_io.py
+++ b/py/desihizmerge/hizmerge_io.py
@@ -1854,7 +1854,7 @@ def get_phot_table(img, case, specinfo_table, photdir, v2=False):
         d["CLAUDS_ZPHOT"] = np.zeros(len(d))
         d["CLAUDS"][iibands[iid]] = True
         d["CLAUDS_ID"][iibands[iid]] = z["ID"][iiz]
-        d["CLAUDS_ZPHOT"][iibands[iid]] = z["Z_BEST"][iiz]
+        d["CLAUDS_ZPHOT"][iibands[iid]] = z["ZPHOT"][iiz]
 
     # clauds cosmos_yr1: at least DESILBG_TMG_FINAL and DESILBG_BXU_FINAL
     #   have objects in common, but those have different TARGETIDs

--- a/py/desihizmerge/hizmerge_io.py
+++ b/py/desihizmerge/hizmerge_io.py
@@ -459,15 +459,19 @@ def read_vi_fn(fn):
 
     # expected file names per img
     basenames = {
-        img : [os.path.basename(_) for _ in get_vi_fns(img)]
-        for img in allowed_imgs
+        img: [os.path.basename(_) for _ in get_vi_fns(img)] for img in allowed_imgs
     }
 
     # odin, suprime
     # - suprime: add dummy VI_SPECTYPE_FINAL
     # - rename columns
     if (basename in basenames["odin"]) | (basename in basenames["suprime"]):
-        key_olds = ["VI_Z_FINAL", "VI_QUALITY_FINAL", "VI_SPECTYPE_FINAL", "VI_COMMENTS_FINAL"]
+        key_olds = [
+            "VI_Z_FINAL",
+            "VI_QUALITY_FINAL",
+            "VI_SPECTYPE_FINAL",
+            "VI_COMMENTS_FINAL",
+        ]
         key_news = ["VI_Z", "VI_QUALITY", "VI_SPECTYPE", "VI_COMMENTS"]
         if basename in basenames["odin"]:
             key_olds = ["VI_TARGETID"] + key_olds
@@ -1749,7 +1753,9 @@ def get_phot_table(img, case, specinfo_table, photdir, v2=False):
 
                     else:
 
-                        log.warning("{} not present in {}".format(key, os.path.basename(targfn)))
+                        log.warning(
+                            "{} not present in {}".format(key, os.path.basename(targfn))
+                        )
 
             # dr or hsc?
             dcut["BB_IMG"] = get_bb_img(targfn)
@@ -1770,8 +1776,9 @@ def get_phot_table(img, case, specinfo_table, photdir, v2=False):
 
                     else:
 
-                        log.warning("{} not present in {}".format(key, os.path.basename(targfn)))
-
+                        log.warning(
+                            "{} not present in {}".format(key, os.path.basename(targfn))
+                        )
 
         if img in ["clauds"]:
 

--- a/py/desihizmerge/hizmerge_io.py
+++ b/py/desihizmerge/hizmerge_io.py
@@ -40,11 +40,6 @@ for img in allowed_img_cases:
     allowed_cases += allowed_img_cases[img]
 allowed_cases = np.unique(allowed_cases).tolist()
 
-# default values
-default_photdir = os.path.join(
-    os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", img, "phot"
-)
-
 
 def print_config_infos():
     """
@@ -70,6 +65,23 @@ def print_config_infos():
 
     #
     log.info("spec_rootdir: {}".format(get_spec_rootdir()))
+
+
+def get_img_dir(img):
+    """
+    Get the "root" folder for an imaging survey.
+
+    Args:
+        img: element from allowed_imgs (str)
+
+    Returns:
+        imgdir: folder path (str)
+    """
+    assert img in allowed_imgs
+    imgdir = os.path.join(
+        os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", img
+    )
+    return imgdir
 
 
 def get_img_bands(img):
@@ -371,14 +383,7 @@ def get_clauds_fn(case, v2=False, uband="u"):
     assert case in allowed_cases
 
     fn = None
-    claudsdir = os.path.join(
-        os.getenv("DESI_ROOT"),
-        "users",
-        "raichoor",
-        "laelbg",
-        "clauds",
-        "phot",
-    )
+    claudsdir = os.path.join(get_img_dir("clauds"), "phot")
 
     field = case[:6]
 
@@ -413,9 +418,7 @@ def get_vi_fns(img):
 
     if img == "odin":
 
-        mydir = os.path.join(
-            os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", "odin", "vi"
-        )
+        mydir = os.path.join(get_img_dir("odin"), "vi")
         fns = [
             os.path.join(mydir, "FINAL_VI_ODIN_N501_20231012.fits"),
             os.path.join(mydir, "FINAL_VI_ODIN_N419_20231114.fits"),
@@ -423,16 +426,12 @@ def get_vi_fns(img):
 
     if img == "suprime":
 
-        mydir = os.path.join(
-            os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", "suprime", "vi"
-        )
+        mydir = os.path.join(get_img_dir("suprime"), "vi")
         fns = [os.path.join(mydir, "FINAL_VI_Subaru_COSMOS_v20230803.fits.gz")]
 
     if img == "clauds":
 
-        mydir = os.path.join(
-            os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", "clauds", "vi"
-        )
+        mydir = os.path.join(get_img_dir("clauds"), "vi")
         fns = [os.path.join(mydir, "desi-vi-truth-table_fuji_V3.ecsv")]
 
     return fns
@@ -1375,9 +1374,9 @@ def get_phot_fns(img, case, band, photdir=None, v2=None):
     assert img in allowed_imgs
     assert case in get_img_cases(img)
 
-    if photdir == None:
+    if photdir is None:
 
-        photdir = default_photdir
+        photdir = os.path.join(get_img_dir(img), "phot")
 
     # odin
     if img == "odin":
@@ -1594,9 +1593,9 @@ def get_phot_table(img, case, specinfo_table, photdir, v2=False):
     assert img in allowed_imgs
     bands = get_img_bands(img)
 
-    if photdir == None:
+    if photdir is None:
 
-        photdir = default_photdir
+        photdir = os.path.join(get_img_dir(img), "phot")
 
     # initializing
     d = get_phot_init_table(img, len(specinfo_table))

--- a/py/desihizmerge/hizmerge_odin.py
+++ b/py/desihizmerge/hizmerge_odin.py
@@ -12,7 +12,7 @@ from astropy import units
 from desitarget.targetmask import desi_mask
 from desiutil.log import get_logger
 from desihizmerge.hizmerge_io import (
-    default_photdir,
+    get_img_dir,
     match_coord,
     get_init_infos,
     get_phot_fns,
@@ -239,9 +239,9 @@ def get_odin_phot_infos(case, d, photdir=None):
         photdir (optional, defaults to $DESI_ROOT/users/raichoor/laelbg/{img}/phot):
             folder where the files are
     """
-    if photdir == None:
+    if photdir is None:
 
-        photdir = default_photdir
+        photdir = os.path.join(get_img_dir("odin"), "phot")
 
     # initialize columns we will fill
     bricknames = np.zeros(len(d), dtype="S8")

--- a/py/desihizmerge/hizmerge_suprime.py
+++ b/py/desihizmerge/hizmerge_suprime.py
@@ -11,7 +11,7 @@ from astropy import units
 from desitarget.targetmask import desi_mask
 from desiutil.log import get_logger
 from desihizmerge.hizmerge_io import (
-    default_photdir,
+    get_img_dir,
     match_coord,
     get_img_bands,
     get_init_infos,
@@ -259,9 +259,9 @@ def get_suprime_phot_infos(case, d, photdir=None, v2=False):
         v2 (optional, default to False): if True, then use Dustin's rerun from 20231025
             (bool)
     """
-    if photdir == None:
+    if photdir is None:
 
-        photdir = default_photdir
+        photdir = os.path.join(get_img_dir("suprime"), "phot")
 
     # initialize columns we will fill
     bricknames = np.zeros(len(d), dtype="S8")

--- a/py/desihizmerge/suprime_photoff_io.py
+++ b/py/desihizmerge/suprime_photoff_io.py
@@ -26,7 +26,7 @@ def get_suprime_dir():
     return os.path.join(os.getenv("DESI_ROOT"), "users", "dstn", "suprime")
 
 
-def get_get_suprime_annotated_ccdfn():
+def get_suprime_annotated_ccdfn():
 
     suprime_dir = get_suprime_dir()
     return os.path.join(suprime_dir, "ccds-annotated-suprime-IA.fits")
@@ -134,7 +134,7 @@ def get_brn_perccd_gausspsfdepths(
     )
 
     # all ccds (to grab ra0, ra1, etc)
-    annotated_ccdfn = get_get_suprime_annotated_ccdfn()
+    annotated_ccdfn = get_suprime_annotated_ccdfn()
     ccd_d = Table.read(annotated_ccdfn)
     sel = ccd_d["filter"] == band.replace("I", "I-A-L")
     ccd_d = ccd_d[sel]
@@ -416,7 +416,7 @@ def apply_offsets(
 
 def plot_suprime_ccd(ax, band, ccdname, **kwargs):
 
-    annotated_ccdfn = get_get_suprime_annotated_ccdfn()
+    annotated_ccdfn = get_suprime_annotated_ccdfn()
     ccd_d = Table.read(annotated_ccdfn)
 
     sel = ccd_d["filter"] == band.replace("I", "I-A-L")

--- a/py/desihizmerge/suprime_photspec_io.py
+++ b/py/desihizmerge/suprime_photspec_io.py
@@ -13,7 +13,7 @@ from desispec.io import read_spectra, write_spectra
 from desispec.coaddition import coadd_cameras, coadd_fibermap
 from desispec.spectra import stack as spectra_stack
 from desiutil.log import get_logger
-from desihizmerge.hizmerge_io import match_coord
+from desihizmerge.hizmerge_io import get_img_dir, match_coord
 
 
 log = get_logger()
@@ -82,9 +82,7 @@ def get_tractor_match(d, tractorfn):
 
 def get_filts(bands, waves):
 
-    filtdir = os.path.join(
-        os.getenv("DESI_ROOT"), "users", "raichoor", "laelbg", "suprime", "filt"
-    )
+    filtdir = os.path.join(get_img_dir("suprime"), "filt")
     myfilts = {}
 
     for band in bands:


### PR DESCRIPTION
This PR adds the scripts to generate a photometric catalog that will be used for angular clustering analysis.
Currently, the scripts only handle {odin,N501,cosmos}, with replicating AD "Selection3" selection.

Also, along the way:
- for the clauds/zphot, replace `Z_BEST`, by `ZPHOT`;
- few code cleaning; in particular, replace the buggy (but harmless so far) `default_photdir` by a `get_img_dir()` function.